### PR TITLE
Fix ADC1 channel selection

### DIFF
--- a/analyze_tonedetect.cpp
+++ b/analyze_tonedetect.cpp
@@ -27,7 +27,7 @@
 #include "analyze_tonedetect.h"
 #include "utility/dspinst.h"
 
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__SAMD51__)
 
 static inline int32_t multiply_32x32_rshift30(int32_t a, int32_t b) __attribute__((always_inline));
 static inline int32_t multiply_32x32_rshift30(int32_t a, int32_t b)

--- a/effect_midside.cpp
+++ b/effect_midside.cpp
@@ -41,7 +41,7 @@ void AudioEffectMidSide::update(void)
 		if (blockb) release(blockb); // of the blocks is NULL then it's trouble anyway
 		return;
 	}
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__SAMD51__)
 	pa = (uint32_t *)(blocka->data);
 	pb = (uint32_t *)(blockb->data);
 	end = pa + AUDIO_BLOCK_SAMPLES/2;

--- a/effect_multiply.cpp
+++ b/effect_multiply.cpp
@@ -28,7 +28,7 @@
 
 void AudioEffectMultiply::update(void)
 {
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__SAMD51__)
 	audio_block_t *blocka, *blockb;
 	uint32_t *pa, *pb, *end;
 	uint32_t a12, a34; //, a56, a78;

--- a/filter_variable.cpp
+++ b/filter_variable.cpp
@@ -45,7 +45,7 @@
 // no audible difference.
 //#define IMPROVE_EXPONENTIAL_ACCURACY
 
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__SAMD51__)
 
 void AudioFilterStateVariable::update_fixed(const int16_t *in,
 	int16_t *lp, int16_t *bp, int16_t *hp)

--- a/synth_dc.h
+++ b/synth_dc.h
@@ -33,7 +33,7 @@
 // compute (a - b) / c
 // handling 32 bit interger overflow at every step
 // without resorting to slow 64 bit math
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__SAMD51__)
 static inline int32_t substract_int32_then_divide_int32(int32_t a, int32_t b, int32_t c) __attribute__((always_inline, unused));
 static inline int32_t substract_int32_then_divide_int32(int32_t a, int32_t b, int32_t c)
 {

--- a/synth_pwm.cpp
+++ b/synth_pwm.cpp
@@ -28,7 +28,7 @@
 #include "utility/dspinst.h"
 
 
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__SAMD51__)
 
 void AudioSynthWaveformPWM::update(void)
 {

--- a/synth_sine.cpp
+++ b/synth_sine.cpp
@@ -51,7 +51,7 @@ void AudioSynthWaveformSine::update(void)
 				scale = (ph >> 8) & 0xFFFF;
 				val2 *= scale;
 				val1 *= 0x10000 - scale;
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__SAMD51__)
 				block->data[i] = multiply_32x32_rshift32(val1 + val2, magnitude);
 #elif defined(KINETISL)
 				block->data[i] = (((val1 + val2) >> 16) * magnitude) >> 16;
@@ -71,7 +71,7 @@ void AudioSynthWaveformSine::update(void)
 
 
 
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__SAMD51__)
 // High accuracy 11th order Taylor Series Approximation
 // input is 0 to 0xFFFFFFFF, representing 0 to 360 degree phase
 // output is 32 bit signed integer, top 25 bits should be very good
@@ -103,7 +103,7 @@ static int32_t taylor(uint32_t ph)
 
 void AudioSynthWaveformSineHires::update(void)
 {
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__SAMD51__)
 	audio_block_t *msw, *lsw;
 	uint32_t i, ph, inc;
 	int32_t val;
@@ -137,7 +137,7 @@ void AudioSynthWaveformSineHires::update(void)
 
 
 
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__SAMD51__)
 
 void AudioSynthWaveformSineModulated::update(void)
 {

--- a/synth_whitenoise.cpp
+++ b/synth_whitenoise.cpp
@@ -44,7 +44,7 @@ void AudioSynthNoiseWhite::update(void)
 	end = p + AUDIO_BLOCK_SAMPLES/2;
 	lo = seed;
 	do {
-#if defined(KINETISK)
+#if defined(KINETISK) || defined(__SAMD51__)
 		hi = multiply_16bx16t(16807, lo); // 16807 * (lo >> 16)
 		lo = 16807 * (lo & 0xFFFF);
 		lo += (hi & 0x7FFF) << 16;


### PR DESCRIPTION
ADC1 needs a different channel from ADC0 in order to operate correctly. The channel is pin dependent. Secondary changes made to enable M4 code using __SAMD51__.